### PR TITLE
Cleanup PHP 5.4 admin notice text; Deactivate Solr Power if PHP is less than 5.4

### DIFF
--- a/solr-power.php
+++ b/solr-power.php
@@ -43,20 +43,50 @@
  *
  */
 
+/**
+ * Echo the admin notice HTML that PHP is less than 5.4
+ * and the Solr Power plugin has been deactivated or
+ * cannot be activated.
+ */
+function solr_power_PHP_admin_notice() {
+	?>
+	<div class="error">
+		<p>
+			<?php
+			if ( isset( $_GET['activate'] ) ) {
+				unset( $_GET['activate'] );
+
+				_e(
+					'The Solr Power plugin requires PHP 5.4 to function properly and <strong>has not</strong> been activated.<br />' .
+					'Please upgrade PHP and re-activate the Solr Power plugin. ' .
+					'<a href="http://www.wpupdatephp.com/update/" target="_blank">Learn more.</a>',
+					'solr-for-wordpress-on-pantheon'
+				);
+			} else {
+				_e(
+					'The Solr Power plugin requires PHP 5.4 to function properly and had been <strong>deactivated</strong>.<br />' .
+					'Please upgrade PHP and re-activate the Solr Power plugin. ' .
+					'<a href="http://www.wpupdatephp.com/update/" target="_blank">Learn more.</a>',
+					'solr-for-wordpress-on-pantheon'
+				);
+			}
+			?>
+		</p>
+	</div>
+	<?php
+}
+
+
+/**
+ * Deactivate the Solr Power plugin
+ */
+function solr_power__deactivate() {
+	deactivate_plugins( plugin_basename( __FILE__ ) );
+}
+
 if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
-	add_action(
-		'admin_notices',
-		create_function(
-			'',
-			"echo '<div class=\"error\"><p>" .
-			__(
-				'Solr Power requires PHP 5.4 to function properly. ' .
-				'Please upgrade PHP or deactivate Solr Power.',
-				'solr-for-wordpress-on-pantheon'
-			) .
-			"</p></div>';"
-		)
-	);
+	add_action( 'admin_notices', 'solr_power_PHP_admin_notice' );
+	add_action( 'admin_init', 'solr_power__deactivate' );
 } else {
 	define( 'SOLR_POWER_PATH', plugin_dir_path( __FILE__ ) . '/' );
 	define( 'SOLR_POWER_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
@allan23 This is for [PR #73 on the main Solr Plugin repo](https://github.com/pantheon-systems/solr-power/pull/73)

Rather than just asking the user to deactivate the Solr Power plugin let's do it automatically and just inform them of the change.

I also added a learn more link to [http://www.wpupdatephp.com/update/](http://www.wpupdatephp.com/update/), which I've seen other plugins use and has some helpful info on how users can upgrade.

Lastly, if the user tried to activate the Solr Power plugin, rather than having an active installation deactivated, I've altered the message slightly.

I've tested this locally on PHP 5.3.29 - please test as well.
